### PR TITLE
Fix canonical and RSS feed URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: Mathieu Mayer
 email: mathieu.mm@me.com
 description: "My name is Mathieu Mayer. I’m a designer. I’ve helped companies like Google, Asics, Indeed or Tokyo Art Beat to create new digital products since 2013."
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "http://mx3m.github.io" # the base hostname & protocol for your site
+url: "https://mathieumayer.com" # the base hostname & protocol for your site
 ga: UA-45562731-1
 
 # Build settings


### PR DESCRIPTION
This fixes:
```
<link rel="canonical" href="http://mx3m.github.io/">
<link rel="alternate" type="application/rss+xml" title="Mathieu Mayer" href="http://mx3m.github.io/feed.xml" />
```
to instead use `mathieumayer.com` domain name
